### PR TITLE
Configure backend to run on port 9000 through application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 9000

--- a/src/test/java/com/danit/ApplicationTest.java
+++ b/src/test/java/com/danit/ApplicationTest.java
@@ -1,0 +1,15 @@
+package com.danit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ApplicationTest {
+
+  @Test
+  public void contextLoads(){
+  }
+}


### PR DESCRIPTION
**IMPORTANT**
After merge, application will run on http://localhost:9000

I thought, maybe if application.properties are in the src/main/resources, it will be a proper place for application.yml
correct me if I'm wrong))

[further readings](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-yaml)
